### PR TITLE
doc: Add Ollama support in the documentation changing the base_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,16 @@ browser:
   headless: true
 ```
 
+Or a local LLM using Ollama
+
+```yaml
+llm:
+  provider: openai
+  model_name: qwq:32b
+  max_tokens: 131072,
+  base_url: http://localhost:11434/v1
+```
+
 ## 🚀 Quick Start
 
 Once installed, you can start using Anus right away:


### PR DESCRIPTION
Ollama supports the [OpenAI API](https://github.com/ollama/ollama/blob/main/docs/openai.md) by changing the base url.

This opens the ability to run this project locally.